### PR TITLE
Enable use in pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+RUN dnf install -y iproute
 COPY client/target/domainproxy-client-1.0.0-SNAPSHOT-runner /app/domainproxy-client-runner
 COPY server/target/domainproxy-server-1.0.0-SNAPSHOT-runner /app/domainproxy-server-runner

--- a/server/src/main/java/io/github/stuartwdouglas/domainproxy/DomainProxyHack.java
+++ b/server/src/main/java/io/github/stuartwdouglas/domainproxy/DomainProxyHack.java
@@ -24,6 +24,7 @@ import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Property;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.Startup;
 
@@ -148,9 +149,11 @@ public class DomainProxyHack {
         }
 
         if (!dependencies.isEmpty()) {
-            BomJsonGenerator bomJsonGenerator = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_15, bom);
             Files.createDirectories(sbomOutputDir);
-            Files.writeString(sbomOutputDir.resolve("sbom.json"), bomJsonGenerator.toJsonString(), StandardCharsets.UTF_8);
+            Path sbom = sbomOutputDir.resolve("sbom.json");
+            Log.infof("Writing SBOM to %s", sbom.toAbsolutePath());
+            BomJsonGenerator bomJsonGenerator = BomGeneratorFactory.createJson(CycloneDxSchema.VERSION_LATEST, bom);
+            Files.writeString(sbom, bomJsonGenerator.toJsonString(), StandardCharsets.UTF_8);
         }
     }
 }

--- a/server/src/main/java/io/github/stuartwdouglas/domainproxy/ReflectionConfiguration.java
+++ b/server/src/main/java/io/github/stuartwdouglas/domainproxy/ReflectionConfiguration.java
@@ -1,0 +1,10 @@
+package io.github.stuartwdouglas.domainproxy;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Property;
+
+@RegisterForReflection(targets = { Bom.class, Component.class, Property.class })
+public class ReflectionConfiguration {
+}


### PR DESCRIPTION
Print location of SBOM when writing. Register necessary classes for reflection. Install iproute as part of Docker image creation process.